### PR TITLE
fix: chunk timeout fixes stall

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -120,7 +120,6 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
         const initialTimeout = 10000; // Initial time out is big
         const chunkTimeout = 10; // Timeout to wait for next chunk
         var timeoutId = setTimeout(() => {
-          done = true;
           controller.abort(); // Abort the fetch if timeout expires
         }, initialTimeout);
         const response = await fetch(endpoint, {

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -115,10 +115,9 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
               ?.requiredKeys.find((key) => key.key === 'GOOGLE_CSE_ID')?.value,
           });
         }
-        let done = false;
         const controller = new AbortController();
         const initialTimeout = 10000; // Initial time out is big
-        const chunkTimeout = 10; // Timeout to wait for next chunk
+        const chunkTimeout = 100; // Timeout to wait for next chunk
         var timeoutId = setTimeout(() => {
           controller.abort(); // Abort the fetch if timeout expires
         }, initialTimeout);
@@ -157,6 +156,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
           const decoder = new TextDecoder();
           let isFirst = true;
           let text = '';
+          let done = false;
           while (!done) {
             if (stopConversationRef.current === true) {
               controller.abort();


### PR DESCRIPTION
- Problem is that long responses stall and the only solution is refresh. 
- Solved using a timeout. If timeout not exceeded, when chunk is read, refresh the timeout. If timeout is exceeded, set messageStreaming to false.
